### PR TITLE
ci: SSH deploy action cleans target directory

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -7,30 +7,31 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
 
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-        cache: 'npm'
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'npm'
 
-    - name: Install Dependencies
-      run: npm i
+      - name: Install Dependencies
+        run: npm i
 
-    - name: Build Supreme Gaming Website
-      run: npx nx run supremegaming-angular:build:production
+      - name: Build Supreme Gaming Website
+        run: npx nx run supremegaming-angular:build:production
 
-    - name: Deploy
-      uses: easingthemes/ssh-deploy@main
-      env:
+      - name: Deploy
+        uses: easingthemes/ssh-deploy@main
+        env:
           SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
-          SOURCE: "dist/apps/supremegaming-angular/"
+          SOURCE: 'dist/apps/supremegaming-angular/'
           REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           TARGET: ${{secrets.REMOTE_TARGET}}
+          ARGS: '-rltgoDzvO --delete'
+


### PR DESCRIPTION
Added default args to deploy stage in main workflow to clear the target folder before copying build files to avoid polluting target directory.