### PR TITLE
ci: Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,10 +36,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/supremegaming/supremegaming-discord-community-bot-node
           flavor: |
             latest=${{ github.event.label.name == 'publish' }}
-            tag=${{ startsWith(github.ref, 'refs/tags/') }}
             ref=${{ github.ref }}
             sha=${{ github.sha }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Build and Publish Images
+
+on:
+  pull_request:
+    types: [labeled]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: 'Download artifacts'
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ github.sha }}
+          path: ~/artifacts
+
+      - name: Docker login
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ github.event.label.name == 'publish' }}
+            tag=${{ startsWith(github.ref, 'refs/tags/') }}
+            ref=${{ github.ref }}
+            sha=${{ github.sha }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          context: ~/artifacts
+          file: ~/artifacts/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/supremegaming/supremegaming-discord-community-bot-node
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=auto
           tags: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,12 @@ jobs:
       - name: 'Set matrix'
         id: set-matrix
         # run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
-        # run: |
-        #   cd artifacts/apps
-        #   echo "::set-output name=matrix::$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
-        run: echo "matrix=['supreme-discord-community-bot-node']" >> $GITHUB_OUTPUT
+        run: |
+          cd ./artifacts/apps
+          echo "matrix=$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
+
+        # run: echo "matrix=['supreme-discord-community-bot-node']" >> $GITHUB_OUTPUT
+        # run: echo "::set-output name=matrix::$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
 
   build-and-push:
     needs: list-publishable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,9 @@ jobs:
         # run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
         run: |
           cd ./artifacts/apps
-          echo $(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')
-          echo "matrix=$(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          JASON=$(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')
+          echo $JASON
+          echo "matrix=$JASON" >> $GITHUB_OUTPUT
   build-and-push:
     needs: list-publishable
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,9 @@ jobs:
           path: artifacts
       - name: 'Set matrix'
         id: set-matrix
-        # run script to generate matrix by getting a list of all directories that have a dockerfile as json array
+        # run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
         run: |
+          cd artifacts/apps
           echo "::set-output name=matrix::$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
 
   build-and-push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: 'Download artifacts'
         uses: actions/download-artifact@v3
         with:
-          name: ${{ github.sha }}
+          name: ${{ github.event.pull_request.head.sha }}
           path: ~/artifacts
 
       - name: Docker login

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
         # run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
         run: |
           cd ./artifacts/apps
+          echo jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique'
           echo "matrix=$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
 
         # run: echo "matrix=['supreme-discord-community-bot-node']" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
       - name: 'Download artifacts'
         uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: build.yml
           name: ${{ github.event.pull_request.head.sha }}
 
       - name: Docker login

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/Supreme-Gaming/supreme-discord-ticket-bot-node
           flavor: |
             latest=auto
           tags: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,14 +16,12 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
       - name: 'Download artifacts'
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: main.yml
           name: ${{ github.event.pull_request.head.sha }}
+          path: artifacts
 
       - name: Docker login
         uses: docker/login-action@v2
@@ -47,8 +45,7 @@ jobs:
       - name: Build and push Docker images
         uses: docker/build-push-action@v3
         with:
-          context: .
-          file: apps/supreme-discord-community-bot-node/Dockerfile
+          context: ./artifacts/apps/supreme-discord-community-bot-node
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Download artifacts'
-        uses: actions/download-artifact@v3
+        uses: dawidd6/action-download-artifact@v2
         with:
           name: ${{ github.event.pull_request.head.sha }}
-          path: ~/artifacts
 
       - name: Docker login
         uses: docker/login-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ~/artifacts
-          file: ~/artifacts/Dockerfile
+          file: ~/artifacts/apps/supreme-discord-community-bot-node/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,32 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  list-publishable:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: 'Download artifacts'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: main.yml
+          name: ${{ github.event.pull_request.head.sha }}
+          path: artifacts
+      - name: 'Set matrix'
+        id: set-matrix
+        # run script to generate matrix by getting a list of all directories that have a dockerfile as json array
+        run: |
+          echo "::set-output name=matrix::$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
+
   build-and-push:
+    needs: list-publishable
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        image: ${{ fromJson(needs.list-publishable.outputs.matrix) }}
 
     steps:
       - name: 'Download artifacts'
@@ -34,7 +55,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/Supreme-Gaming/supreme-discord-ticket-bot-node
+          images: ${{ env.REGISTRY }}/Supreme-Gaming/${{ matrix.image }}
           flavor: |
             latest=true
           tags: |
@@ -45,7 +66,8 @@ jobs:
       - name: Build and push Docker images
         uses: docker/build-push-action@v3
         with:
-          context: ./artifacts/apps/supreme-discord-community-bot-node
+          context: ./artifacts/apps/${{ matrix.image }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,10 @@ jobs:
       - name: 'Set matrix'
         id: set-matrix
         # run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
-        run: |
-          cd artifacts/apps
-          echo "::set-output name=matrix::$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
+        # run: |
+        #   cd artifacts/apps
+        #   echo "::set-output name=matrix::$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
+        run: echo "matrix=['supreme-discord-community-bot-node']" >> $GITHUB_OUTPUT
 
   build-and-push:
     needs: list-publishable
@@ -36,7 +37,6 @@ jobs:
     strategy:
       matrix:
         image: ${{ fromJson(needs.list-publishable.outputs.matrix) }}
-
     steps:
       - name: 'Download artifacts'
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: 'Download artifacts'
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: build.yml
+          workflow: main.yml
           name: ${{ github.event.pull_request.head.sha }}
 
       - name: Docker login

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,8 @@ jobs:
         # run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
         run: |
           cd ./artifacts/apps
-          pwd && ls -la
-          echo $(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R . | jq -s .;)
-          echo "matrix=$(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R . | jq -s .;)" >> $GITHUB_OUTPUT
-
-        # run: echo "matrix=['supreme-discord-community-bot-node']" >> $GITHUB_OUTPUT
-
+          echo $(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')
+          echo "matrix=$(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
   build-and-push:
     needs: list-publishable
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ env:
 
 jobs:
   list-publishable:
+    # Only run this job if pull request label is equal to "release"
+    # If this condition fails, build-and-publish will not run
+    if: ${{ github.event.label.name == 'release' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -22,7 +25,7 @@ jobs:
           path: artifacts
       - name: 'Set matrix'
         id: set-matrix
-        # run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
+        # Run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
         run: |
           cd ./artifacts/apps
           JASON=$(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,8 @@ jobs:
         # run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
         run: |
           cd ./artifacts/apps
-          echo jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique'
+          pwd && ls -la
+          echo $(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R . | jq -s .;)
           echo "matrix=$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
 
         # run: echo "matrix=['supreme-discord-community-bot-node']" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,9 @@ jobs:
           cd ./artifacts/apps
           pwd && ls -la
           echo $(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R . | jq -s .;)
-          echo "matrix=$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
+          echo "matrix=$(find . -name "Dockerfile" -exec dirname {} \; | sed 's/^\.\///' | jq -R . | jq -s .;)" >> $GITHUB_OUTPUT
 
         # run: echo "matrix=['supreme-discord-community-bot-node']" >> $GITHUB_OUTPUT
-        # run: echo "::set-output name=matrix::$(jq -nR '[inputs | select(contains("Dockerfile")) | split("/") | .[0]] | unique')"
 
   build-and-push:
     needs: list-publishable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/supremegaming/supremegaming-discord-community-bot-node
           flavor: |
@@ -47,8 +47,8 @@ jobs:
       - name: Build and push Docker images
         uses: docker/build-push-action@v3
         with:
-          context: ~/artifacts
-          file: ~/artifacts/apps/supreme-discord-community-bot-node/Dockerfile
+          context: .
+          file: apps/supreme-discord-community-bot-node/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,9 +38,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/supremegaming/supremegaming-discord-community-bot-node
           flavor: |
-            latest=${{ github.event.label.name == 'publish' }}
-            ref=${{ github.ref }}
-            sha=${{ github.sha }}
+            latest=auto
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/Supreme-Gaming/supreme-discord-ticket-bot-node
           flavor: |
-            latest=auto
+            latest=true
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/apps/supreme-discord-community-bot-node/src/Dockerfile
+++ b/apps/supreme-discord-community-bot-node/src/Dockerfile
@@ -2,6 +2,6 @@ FROM node:16.17.0
 ENV NODE_ENV=production
 WORKDIR /app
 COPY package*.json ./
-RUN npm i --omit=dev
+RUN npm i --omit=dev --legacy-peer-deps
 COPY . ./
 CMD ["node", "main.js"]

--- a/apps/supreme-discord-ticket-bot-node/src/Dockerfile
+++ b/apps/supreme-discord-ticket-bot-node/src/Dockerfile
@@ -2,6 +2,6 @@ FROM node:16.17.0
 ENV NODE_ENV=production
 WORKDIR /app
 COPY package*.json ./
-RUN npm i --omit=dev
+RUN npm i --omit=dev --legacy-peer-deps
 COPY . ./
 CMD ["node", "main.js"]


### PR DESCRIPTION
Adds a build and publish docker image workflow consisting of two jobs:

- Generating a list of publishable applications from the artifacts produced by the build workflow
- For each of the publishable applications in the artifacts, build the docker image and push it to GitHub packages.

This PR commit history is messy, so the commits don't make much sense. Did clear out the ones that were obvious noise. 