### PR TITLE
ci: Docker image size optimizations

### DIFF
--- a/apps/supreme-discord-community-bot-node/dev.docker-compose.yml
+++ b/apps/supreme-discord-community-bot-node/dev.docker-compose.yml
@@ -1,0 +1,22 @@
+# Compose file for local testing
+# Same can be used for production, just swap out the image name
+#
+# To run:
+#   docker-compose -f dev.docker-compose.yml --env-file .env.local up -d
+
+version: '3'
+
+name: SG Community Bot
+services:
+  dev:
+    image: supreme-discord-community-bot-node:latest
+    container_name: supreme-discord-community-bot-node
+    restart: always
+    environment:
+      DISCORD_API_TOKEN: ${DISCORD_API_TOKEN}
+      DISCORD_BOT_ID: ${DISCORD_BOT_ID}
+      DISCORD_GUILD_ID: ${DISCORD_GUILD_ID}
+      DISCORD_REGISTER_SLASH_COMMANDS: ${DISCORD_REGISTER_SLASH_COMMANDS}
+      DISCORD_ROLE_CHANNEL_NAME: ${DISCORD_ROLE_CHANNEL_NAME}
+      DISCORD_WELCOME_CHANNEL_NAME: ${DISCORD_WELCOME_CHANNEL_NAME}
+

--- a/apps/supreme-discord-community-bot-node/src/Dockerfile
+++ b/apps/supreme-discord-community-bot-node/src/Dockerfile
@@ -1,7 +1,11 @@
-FROM node:16.17.0
+FROM node:16.17.0 as builder
 ENV NODE_ENV=production
 WORKDIR /app
 COPY package*.json ./
 RUN npm i --omit=dev --legacy-peer-deps
 COPY . ./
+
+FROM node:16.17.0-alpine
+WORKDIR /app
+COPY --from=builder /app .
 CMD ["node", "main.js"]

--- a/apps/supreme-discord-ticket-bot-node/dev.docker-compose.yml
+++ b/apps/supreme-discord-ticket-bot-node/dev.docker-compose.yml
@@ -1,0 +1,30 @@
+# Compose file for local testing
+# Same can be used for production, just swap out the image name
+#
+# To run:
+#   docker-compose -f dev.docker-compose.yml --env-file .env.local up -d
+
+version: '3'
+
+name: SG Ticket Bot
+services:
+  dev:
+    image: supreme-discord-ticket-bot-node:latest
+    container_name: supreme-discord-ticket-bot-node
+    restart: always
+    environment:
+      DISCORD_API_TOKEN: ${DISCORD_API_TOKEN}
+      DISCORD_BOT_ID: ${DISCORD_BOT_ID}
+      DISCORD_GUILD_ID: ${DISCORD_GUILD_ID}
+      DISCORD_REGISTER_SLASH_COMMANDS: ${DISCORD_REGISTER_SLASH_COMMANDS}
+      TYPEORM_CONNECTION: ${TYPEORM_CONNECTION}
+      TYPEORM_HOST: ${TYPEORM_HOST}
+      TYPEORM_PORT: ${TYPEORM_PORT}
+      TYPEORM_USERNAME: ${TYPEORM_USERNAME}
+      TYPEORM_PASSWORD: ${TYPEORM_PASSWORD}
+      TYPEORM_DATABASE: ${TYPEORM_DATABASE}
+      TYPEORM_SYNCHRONIZE: ${TYPEORM_SYNCHRONIZE}
+      TYPEORM_DROP_SCHEMA: ${TYPEORM_DROP_SCHEMA}
+      TYPEORM_LOGGING: ${TYPEORM_LOGGING}
+      TYPEORM_DRIVER_EXTRA: ${TYPEORM_DRIVER_EXTRA}
+

--- a/apps/supreme-discord-ticket-bot-node/src/Dockerfile
+++ b/apps/supreme-discord-ticket-bot-node/src/Dockerfile
@@ -1,7 +1,11 @@
-FROM node:16.17.0
+FROM node:16.17.0 as builder
 ENV NODE_ENV=production
 WORKDIR /app
 COPY package*.json ./
 RUN npm i --omit=dev --legacy-peer-deps
 COPY . ./
+
+FROM node:16.17.0-alpine
+WORKDIR /app
+COPY --from=builder /app .
 CMD ["node", "main.js"]


### PR DESCRIPTION
Reduced final container size of both discord bot images from 800-900MB to ~150MB each by using multi-stage builds.

Added sample dev docker-compose files for easier testing.

`docker compose -f dev.docker-compose.yml --env-file .env.local up -d`
