### PR TITLE
fix(discord-ticket-bot): Changed all discord ID props from number to string

### DIFF
--- a/libs/discord/ticket/src/lib/discord-ticket.ts
+++ b/libs/discord/ticket/src/lib/discord-ticket.ts
@@ -136,7 +136,7 @@ export class TicketClient implements SlashCommands, OnMessageCreate, OnMessageUp
 
   private async setup(message: Message) {
     // Ticket configurations are stored by discord guild ID.
-    const serverId = parseInt(message.guild.id);
+    const serverId = message.guild.id;
 
     const config = await new TicketServerConfiguration(serverId).fetch();
 
@@ -306,7 +306,7 @@ export class TicketClient implements SlashCommands, OnMessageCreate, OnMessageUp
       // Get ticket server configuration.
       // This will contain channel category to add ticket to and
       // role to tag on ticket creation.
-      const config = await new TicketServerConfiguration(parseInt(interaction.guild.id)).fetch();
+      const config = await new TicketServerConfiguration(interaction.guild.id).fetch();
 
       if (!config.fromDb) {
         interaction.reply('Ticket service not configured. Type `!ticket setup` to setup the service.');

--- a/libs/discord/ticket/src/lib/entities/ticket-attachment.entity.ts
+++ b/libs/discord/ticket/src/lib/entities/ticket-attachment.entity.ts
@@ -6,10 +6,10 @@ export class TicketAttachment {
   public id: number;
 
   @PrimaryColumn({ type: 'bigint' })
-  public serverId: number;
+  public serverId: string;
 
   @PrimaryColumn({ type: 'bigint' })
-  public messageId: number;
+  public messageId: string;
 
   @Column({ type: 'text' })
   public name: string;

--- a/libs/discord/ticket/src/lib/entities/ticket-configuration.entity.ts
+++ b/libs/discord/ticket/src/lib/entities/ticket-configuration.entity.ts
@@ -6,7 +6,7 @@ export class TicketConfiguration {
   public id: number;
 
   @Column({ type: 'bigint' })
-  public serverId: number;
+  public serverId: string;
 
   @Column({ type: 'json' })
   public config: object;

--- a/libs/discord/ticket/src/lib/entities/ticket-message.entity.ts
+++ b/libs/discord/ticket/src/lib/entities/ticket-message.entity.ts
@@ -6,19 +6,19 @@ export class TicketMessageEntity {
   public id: number;
 
   @PrimaryColumn({ type: 'bigint' })
-  public serverId: number;
+  public serverId: string;
 
   @Column()
   public ticketId: string;
 
   @Column({ type: 'bigint' })
-  public createdBy: number;
+  public createdBy: string;
 
   @Column()
   public authorName: string;
 
   @PrimaryColumn({ type: 'bigint' })
-  public messageId: number;
+  public messageId: string;
 
   @Column({ type: 'text' })
   public content: string;

--- a/libs/discord/ticket/src/lib/entities/ticket.entity.ts
+++ b/libs/discord/ticket/src/lib/entities/ticket.entity.ts
@@ -9,16 +9,16 @@ export class TicketEntity {
   public ticketId: string;
 
   @Column({ type: 'bigint' })
-  public serverId: number;
+  public serverId: string;
 
   @Column({ type: 'bigint' })
-  public serverSequence: number;
+  public serverSequence: string;
 
   @Column({ type: 'bigint' })
-  public createdBy: number;
+  public createdBy: string;
 
   @Column({ type: 'bigint' })
-  public channelId: number;
+  public channelId: string;
 
   @Column({ default: 'open' })
   public status: string;

--- a/libs/discord/ticket/src/lib/features/discord-server-configuration.feature.ts
+++ b/libs/discord/ticket/src/lib/features/discord-server-configuration.feature.ts
@@ -9,7 +9,7 @@ export class TicketServerConfiguration {
     notifyRole: 'admin',
   };
   public fromDb = false;
-  constructor(serverId: number) {
+  constructor(serverId: string) {
     if (serverId) {
       this._config.serverId = serverId;
     } else {
@@ -19,12 +19,12 @@ export class TicketServerConfiguration {
 
   public set category(response: Collection<string, Message>) {
     this._config.category = response.first().content;
-    this._config.serverId = parseInt(response.first().guild.id);
+    this._config.serverId = response.first().guild.id;
   }
 
   public set notifyRole(response: Collection<string, Message>) {
     this._config.notifyRole = response.first().cleanContent.replace('@', '');
-    this._config.serverId = parseInt(response.first().guild.id);
+    this._config.serverId = response.first().guild.id;
   }
 
   public get value() {
@@ -74,5 +74,5 @@ export class TicketServerConfiguration {
 export interface DiscordTicketServerConfigurationProperties {
   category: string;
   notifyRole: string;
-  serverId?: number;
+  serverId?: string;
 }

--- a/libs/discord/ticket/src/lib/features/discord-ticket-message-attachment.feature.ts
+++ b/libs/discord/ticket/src/lib/features/discord-ticket-message-attachment.feature.ts
@@ -5,12 +5,12 @@ import { MessageAttachment } from 'discord.js';
 export class DiscordServerTicketMessageAttachment {
   private _repo: Repository<TicketAttachment>;
 
-  private _serverId: number;
-  private _messageId: number;
+  private _serverId: string;
+  private _messageId: string;
 
   private _attachments: MessageAttachment[];
 
-  constructor(serverId: number, messageId: number, attachments: MessageAttachment[]) {
+  constructor(serverId: string, messageId: string, attachments: MessageAttachment[]) {
     this._repo = getRepository(TicketAttachment);
 
     this._serverId = serverId;

--- a/libs/discord/ticket/src/lib/features/discord-ticket-message.feature.ts
+++ b/libs/discord/ticket/src/lib/features/discord-ticket-message.feature.ts
@@ -12,11 +12,11 @@ export class TicketMessage {
 
   private _messageContent: string;
   private _messageAttachments: Array<MessageAttachment>;
-  private _messageId: number;
-  private _createdBy: number;
+  private _messageId: string;
+  private _createdBy: string;
   private _authorName: string;
-  private _channelId: number;
-  private _serverId: number;
+  private _channelId: string;
+  private _serverId: string;
 
   private _channelName: string;
 
@@ -46,13 +46,13 @@ export class TicketMessage {
   private async applyMetadata(message: Message | PartialMessage) {
     this._channelName = (message.channel as TextChannel).name;
 
-    this._messageId = parseInt(message.id);
+    this._messageId = message.id;
     this._messageContent = message.cleanContent;
 
     this._messageAttachments = message.attachments.map((a) => a);
 
-    this._channelId = parseInt(message.channel.id);
-    this._serverId = parseInt(message.guild.id);
+    this._channelId = message.channel.id;
+    this._serverId = message.guild.id;
 
     // Check if the message has a valid author. Bot's might not populate this property.
     if (message.author === null) {
@@ -63,7 +63,7 @@ export class TicketMessage {
       await message.author.fetch();
     }
 
-    this._createdBy = parseInt(message.author.id);
+    this._createdBy = message.author.id;
     this._authorName = message.author.username;
   }
 

--- a/libs/discord/ticket/src/lib/features/discord-tickets.feature.ts
+++ b/libs/discord/ticket/src/lib/features/discord-tickets.feature.ts
@@ -6,10 +6,10 @@ import * as guid from 'uuid/v4';
 
 export class Ticket {
   private _repo: Repository<TicketEntity>;
-  private _serverId: number;
-  private _seq: number;
-  private _createdBy: number;
-  private _channelId: number;
+  private _serverId: string;
+  private _seq: string;
+  private _createdBy: string;
+  private _channelId: string;
 
   /**
    * This is set to true once the ticket insertion query has finished.
@@ -21,8 +21,8 @@ export class Ticket {
 
   constructor(interaction: CommandInteraction<CacheType> | ButtonInteraction<CacheType>) {
     this._repo = getRepository(TicketEntity);
-    this._serverId = parseInt(interaction.guild.id);
-    this._createdBy = parseInt(interaction.user.id);
+    this._serverId = interaction.guild.id;
+    this._createdBy = interaction.user.id;
 
     if ((interaction.channel as any).name.includes('ticket')) {
       this.channelId = interaction.channel.id;
@@ -97,7 +97,7 @@ export class Ticket {
   }
 
   public set channelId(id: string) {
-    this._channelId = parseInt(id);
+    this._channelId = id;
   }
 
   private async getDbSequence() {
@@ -108,9 +108,10 @@ export class Ticket {
       .execute();
 
     if (seq.length > 0 && seq[0].val !== null) {
-      return parseInt(seq[0].val) + 1;
+      const curr = seq[0].val;
+      return (parseInt(curr) + 1).toString();
     } else {
-      return 1;
+      return '1';
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2020",
     "module": "esnext",
     "typeRoots": ["node_modules/@types"],
     "lib": ["esnext", "dom"],


### PR DESCRIPTION
They are stored as bigint's in the database, but most IDs (user, guild, message, etc.) are much larger than the number type can represent. Using the bigint type in JS results in serialization errors, leaving the serialization as a string to preserve accuracy without changing the DB model.