### PR TITLE
fix(discord-ticket-bot): Update discord.js dep to fix `channel.isText()` not a function error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@nestjs/passport": "9.0.0",
         "@nestjs/platform-express": "9.0.0",
         "@nestjs/typeorm": "9.0.1",
-        "discord.js": "^13.12.0",
+        "discord.js": "^13.14.0",
         "marked": "^1.2.7",
         "mysql": "^2.18.1",
         "passport": "^0.4.1",
@@ -10182,9 +10182,9 @@
       }
     },
     "node_modules/discord.js": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.12.0.tgz",
-      "integrity": "sha512-K5qhREsYcTHkEqt7+7LcSoXTeQYZpI+SQRs9ei/FhbhUpirmjqFtN99P8W2mrKUyhhy7WXWm7rnna0AooKtIpw==",
+      "version": "13.14.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.14.0.tgz",
+      "integrity": "sha512-EXHAZmFHMf6qBHDsIANwSG792SYJpzEFv2nssfakyDqEn0HLxFLLXMaOxBtVohdkUMgtD+dzyeBlbDvAW/A0AA==",
       "dependencies": {
         "@discordjs/builders": "^0.16.0",
         "@discordjs/collection": "^0.7.0",
@@ -29252,9 +29252,9 @@
       "dev": true
     },
     "discord.js": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.12.0.tgz",
-      "integrity": "sha512-K5qhREsYcTHkEqt7+7LcSoXTeQYZpI+SQRs9ei/FhbhUpirmjqFtN99P8W2mrKUyhhy7WXWm7rnna0AooKtIpw==",
+      "version": "13.14.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.14.0.tgz",
+      "integrity": "sha512-EXHAZmFHMf6qBHDsIANwSG792SYJpzEFv2nssfakyDqEn0HLxFLLXMaOxBtVohdkUMgtD+dzyeBlbDvAW/A0AA==",
       "requires": {
         "@discordjs/builders": "^0.16.0",
         "@discordjs/collection": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@nestjs/passport": "9.0.0",
     "@nestjs/platform-express": "9.0.0",
     "@nestjs/typeorm": "9.0.1",
-    "discord.js": "^13.12.0",
+    "discord.js": "^13.14.0",
     "marked": "^1.2.7",
     "mysql": "^2.18.1",
     "passport": "^0.4.1",


### PR DESCRIPTION
Issue explained here:

https://discord.com/channels/222078108977594368/769862166131245066/1090766967302008872

Suddenly, bots started throwing the `TypeError channel.isTextBased is not a function/channel.isText is not a function error. This is solved by bumping the package version.