### PR TITLE
feat(discord-community-bot): Add wrong discord server reply

### DIFF
--- a/libs/discord/community/src/lib/miscellaneous/fun/fun.module.ts
+++ b/libs/discord/community/src/lib/miscellaneous/fun/fun.module.ts
@@ -19,7 +19,8 @@ export class FunDiscordModule implements SlashCommands, OnInteractionCreate {
               { name: 'Never gonna', value: 'giveYouUp' },
               { name: 'If you like it', value: 'putARingOnIt' },
               { name: 'Am I real boy?', value: 'creator' },
-              { name: 'LF: Passive pen', value: 'passivePen' }
+              { name: 'LF: Passive pen', value: 'passivePen' },
+              { name: 'Wrong discord', value: 'wrongDiscord' }
             );
         }),
     ];
@@ -42,6 +43,11 @@ export class FunDiscordModule implements SlashCommands, OnInteractionCreate {
           break;
         case 'passivePen':
           interaction.reply('Trading one passive pen for 5k hard poly and 5k cp');
+          break;
+        case 'wrongDiscord':
+          interaction.reply({
+            files: ['https://cdn.discordapp.com/attachments/262744296875229185/1092881251775545474/SupremeARKmod.png'],
+          });
           break;
         default:
           break;


### PR DESCRIPTION
Adds a command to the /random slash command category to quick reply to users that joined the wrong discord. 