### PR TITLE
chore(ci): Remove legacy peer deps install option from all configs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Build Affected
         run: npx nx affected:build --configuration=production --exclude=ark-cacher-node,conan-cacher,data-api-nest  --base=origin/development --parallel=2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Lint Affected
         run: npx nx affected:lint --configuration=production --exclude=ark-cacher-node,conan-cacher,data-api-nest  --base=origin/development --parallel=2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,4 +74,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-

--- a/apps/supreme-discord-community-bot-node/src/Dockerfile
+++ b/apps/supreme-discord-community-bot-node/src/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.17.0 as builder
 ENV NODE_ENV=production
 WORKDIR /app
 COPY package*.json ./
-RUN npm i --omit=dev --legacy-peer-deps
+RUN npm i --omit=dev
 COPY . ./
 
 FROM node:16.17.0-alpine

--- a/apps/supreme-discord-ticket-bot-node/src/Dockerfile
+++ b/apps/supreme-discord-ticket-bot-node/src/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.17.0 as builder
 ENV NODE_ENV=production
 WORKDIR /app
 COPY package*.json ./
-RUN npm i --omit=dev --legacy-peer-deps
+RUN npm i --omit=dev
 COPY . ./
 
 FROM node:16.17.0-alpine


### PR DESCRIPTION
This was initially a workaround for a problem I did not want to fix at the time and is fixed now.