### PR TITLE
fix(discord-community-bot): Remove welcome channel link for new members

### DIFF
--- a/libs/discord/community/src/lib/support/membership/new-member.module.ts
+++ b/libs/discord/community/src/lib/support/membership/new-member.module.ts
@@ -8,10 +8,10 @@ export class NewMemberDiscordModule implements OnGuildMemberAdd {
       (c) => c.name == process.env.DISCORD_WELCOME_CHANNEL_NAME
     ) as TextChannel;
 
-    const roleChannel = member.guild.channels.cache.find((c) => c.name === process.env.DISCORD_ROLE_CHANNEL_NAME);
+    // const roleChannel = member.guild.channels.cache.find((c) => c.name === process.env.DISCORD_ROLE_CHANNEL_NAME);
 
     defaultChannel.send(
-      `Welcome to Supreme Gaming ${member}!\n\nTo unlock more channels, you'll need to assign yourself some Discord roles for the games you're here for. Click on the below channel link to do that:\n\n${roleChannel}\n${roleChannel}\n${roleChannel}\n${roleChannel}\n${roleChannel}\n${roleChannel}\n${roleChannel}\n\nType \`!help\` for a list of available commands.`
+      `Welcome to Supreme Gaming ${member}!\n\nTo unlock more channels, you'll need to assign yourself some Discord roles for the games you're here for. Head over to the Roles & Channels onboarding page to get started.`
     );
   }
 }


### PR DESCRIPTION
Removes the reference to a welcome channel on new member join due to the introduction of the onboarding process for community servers.