### PR TITLE
ci: Change image build trigger strategy to release publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Build and Publish Images
 
 on:
-  pull_request:
-    types: [labeled]
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This changes the trigger to start the build and publish container images from release tag added to PR, to release published.