### PR TITLE
ci: Fix build and publish file injections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
           echo ""
           echo "Listing dist/apps"
           ls dist/apps/
+
           shopt -u nullglob
 
         # Static angular applications can have environment variables injected at container runtime using the
@@ -76,6 +77,7 @@ jobs:
 
           echo ""
           echo "Listing dist/apps"
+          ls dist/apps/
 
           shopt -u nullglob
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,20 @@ jobs:
       - name: Inject Package JSON
         run: |
           shopt -s nullglob
+
+          # Check if dist/apps exists
+          if [ ! -d dist/apps ]; then
+            echo "dist/apps does not exist"
+            exit 0
+          fi
+
           for d in dist/apps/*-nest; do
             echo "Copying package.json to $d"
             cp package.json "$d"
           done
+
+          echo ""
+          echo "Listing dist/apps"
           ls dist/apps/
           shopt -u nullglob
 
@@ -52,11 +62,21 @@ jobs:
       - name: Inject Token Subsitution Script
         run: |
           shopt -s nullglob
+
+          # Check if dist/apps exists
+          if [ ! -d dist/apps ]; then
+            echo "dist/apps does not exist"
+            exit 0
+          fi
+
           for d in dist/apps/*-angular; do
             echo "Copying tokenSubstitute.sh to $d"
             cp scripts/ci/tokenSubstitute.sh "$d"
           done
-          ls dist/apps/
+
+          echo ""
+          echo "Listing dist/apps"
+
           shopt -u nullglob
 
       - name: Upload Build Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,14 +38,26 @@ jobs:
         # and the more common issue is missing required database drivers.
       - name: Inject Package JSON
         run: |
-          for d in dist/apps/*-nest; do cp package.json $d; done
+          shopt -s nullglob
+          for d in dist/apps/*-nest; do
+            echo "Copying package.json to $d"
+            cp package.json "$d"
+          done
+          ls dist/apps/
+          shopt -u nullglob
 
         # Static angular applications can have environment variables injected at container runtime using the
         # tokenSubstitute.sh script. This script is copied to the dist/apps/<project-name>-angular folder.
         #
       - name: Inject Token Subsitution Script
         run: |
-          for d in dist/apps/*-angular; do cp scripts/ci/tokenSubstitute.sh $d; done; ls dist/apps/
+          shopt -s nullglob
+          for d in dist/apps/*-angular; do
+            echo "Copying tokenSubstitute.sh to $d"
+            cp scripts/ci/tokenSubstitute.sh "$d"
+          done
+          ls dist/apps/
+          shopt -u nullglob
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         #
       - name: Inject Token Subsitution Script
         run: |
-          for d in dist/apps/*-angular; do cp scripts/ci/tokenSubstitute.sh $d; done
+          for d in dist/apps/*-angular; do cp scripts/ci/tokenSubstitute.sh $d; done; ls dist/apps/
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fix steps that inject `package.json` file to all `*-nest` apps and token sub script to all `*-angular` apps.