### PR TITLE
fix(discord-community-bot-node): Fix random command image path

### DIFF
--- a/libs/discord/community/src/lib/miscellaneous/fun/fun.module.ts
+++ b/libs/discord/community/src/lib/miscellaneous/fun/fun.module.ts
@@ -46,7 +46,7 @@ export class FunDiscordModule implements SlashCommands, OnInteractionCreate {
           break;
         case 'wrongDiscord':
           interaction.reply({
-            files: ['https://cdn.discordapp.com/attachments/262744296875229185/1092881251775545474/SupremeARKmod.png'],
+            files: ['http://static.supremegaming.gg/images/misc/SupremeARKmod.png'],
           });
           break;
         default:


### PR DESCRIPTION
The old path was linking to the discord-hosted image, which went poof. Migrated the image to static.supremegamin.gg and updated the path in the bot. 