### PR TITLE
feat: Replace atlas server grid with atlas-map iframe

### DIFF
--- a/libs/pages/public/src/lib/games/modules/atlas/modules/atlas-overview/atlas-overview.component.html
+++ b/libs/pages/public/src/lib/games/modules/atlas/modules/atlas-overview/atlas-overview.component.html
@@ -2,4 +2,17 @@
 
 <p>Become a pirate and sail the seven seas (technically 64, actually) in a massive 8x8 hybrid PVE and PVE grid.</p>
 
-<supremegaming-server-grid-list class="leader-3" [servers]="servers | async"></supremegaming-server-grid-list>
+<!-- <supremegaming-server-grid-list class="leader-3" [servers]="servers | async"></supremegaming-server-grid-list> -->
+
+<div class="iframe-wrapper leader-3" style="height: calc(90vh - 2.5rem)">
+  <iframe
+    src="https://supremegaming.gg/atlas-map/"
+    title="Atlas overview"
+    loading="lazy"
+    referrerpolicy="no-referrer"
+    frameborder="0"
+    allowfullscreen
+    height="100%"
+    width="100%"
+  ></iframe>
+</div>


### PR DESCRIPTION
This pull request updates the Atlas Overview page to embed an interactive map instead of displaying the server grid list. The server grid list component is now commented out, and an iframe pointing to the external Atlas map has been added for a more visual and interactive experience.

UI changes:

* Replaced the `supremegaming-server-grid-list` component with an iframe embedding the external Atlas map at `https://supremegaming.gg/atlas-map/` in `atlas-overview.component.html`.